### PR TITLE
test: add tests for queries with fragment and alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,10 @@ Automatic generation of federated schema supports
   - [ ] provide fields that need to be resolved (from `context.__currentQuery`?)
   - [ ] (from mercurius gateway) do not query `__resolveReference` if not necessary
 - [ ] 100% test coverage
-  - [ ] forwarded queries with fragments and alias (probably already supported, write tests)
 - [ ] use a model for `__resolveReference` - `{ query, variables, transform (jsonata) }`
 - [ ] more advanced examples in "How it works" section
 - [ ] support subscriptions in schema/resolvers
 - [ ] comments in federated schema
 - [ ] jsdoc and type check
 - [ ] expose `buildFederatedInfo` and document it
+- [ ] field aliasing on forwarded queries

--- a/test/build-federated-info.test.js
+++ b/test/build-federated-info.test.js
@@ -16,7 +16,7 @@ const db = {
 
 const cases = [
   {
-    name: 'should federate an "hello world" service',
+    name: 'should federate a "hello world" service',
     schema: dedent`
     type Query {
       hello (greeting: String!): String
@@ -41,7 +41,7 @@ const cases = [
   },
 
   {
-    name: 'should federate an basic service with a custom type and @key directives',
+    name: 'should federate a basic service with a custom type and @key directives',
     schema: dedent`
     type Query {
       me: User

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -42,7 +42,7 @@ const cases = [
   },
 
   {
-    name: 'should federate an basic service with a custom type',
+    name: 'should federate a basic service with a custom type',
     schema: dedent`
     type Query {
       me: User
@@ -78,7 +78,7 @@ const cases = [
   },
 
   {
-    name: 'should federate an basic service with @key directive',
+    name: 'should federate a basic service with @key directive',
     schema: dedent`
     type Query {
       me: User
@@ -117,7 +117,7 @@ const cases = [
   },
 
   {
-    name: 'should federate an basic service with enum',
+    name: 'should federate a basic service with enum',
     schema: dedent`
     type Query {
       me: User
@@ -162,7 +162,7 @@ const cases = [
   },
 
   {
-    name: 'should federate an complete service with mutations and directives',
+    name: 'should federate a complete service with mutations and directives',
     schema: dedent`
     type Post {
       pid: ID!


### PR DESCRIPTION
Closes #11 

This PR adds tests which check if queries with fragments or aliases are forwarded correctly to the target service from the created federated service.

Queries with fragments work as expected.

Aliasing the query works as expected, as does aliasing results when using the same query more than once.

Aliasing fields in response to the query is not supported out of the box - a new issue has been created to track implementation of this #26 

Also renames test/build-federated-info.test.js so that it is picked up by the test runner