### PR TITLE
fix: adding missing data on package.json to use npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,13 @@
     "merge-options": "^3.0.4",
     "rfdc": "^1.3.0",
     "undici": "^5.3.0"
+  },
+  "homepage": "https://github.com/nearform/graphql-auto-federate",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nearform/graphql-auto-federate.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nearform/graphql-auto-federate/issues"
   }
 }


### PR DESCRIPTION
- Resolves #229 