### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "fastify": "^4.0.3",
         "get-port": "7.1.0",
-        "husky": "^9.0.10",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.1",
         "mercurius": "^14.0.0",
         "prettier": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "fastify": "^4.0.3",
     "get-port": "7.1.0",
-    "husky": "^9.0.10",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.1",
     "mercurius": "^14.0.0",
     "prettier": "^3.0.1",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)