### PR TITLE
chore(deps): consolidate Dependabot updates

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -119,9 +119,7 @@ function isResolveReferenceDefined(typeName, options, resolvers) {
   return Boolean(
     (options.resolvers[typeName] &&
       options.resolvers[typeName].__resolveReference) ||
-      (resolvers &&
-        resolvers[typeName] &&
-        resolvers[typeName].__resolveReference)
+    (resolvers && resolvers[typeName] && resolvers[typeName].__resolveReference)
   )
 }
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -73,8 +73,8 @@ function validateUrl(url) {
 
   try {
     new URL(url)
-  } catch (_) {
-    throw new Error('buildFederatedService: url must be valid')
+  } catch (err) {
+    throw new Error('buildFederatedService: url must be valid', { cause: err })
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
-        "@eslint/js": "^9.39.5",
+        "@eslint/js": "^10.0.1",
         "@mercuriusjs/federation": "^5.1.1",
         "@mercuriusjs/gateway": "^5.2.0",
         "dedent": "^1.0.2",
@@ -30,7 +30,7 @@
         "husky": "^9.0.11",
         "lint-staged": "^17.1.0",
         "mercurius": "^16.10.0",
-        "prettier": "^3.0.1"
+        "prettier": "^3.9.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -449,16 +449,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -3375,10 +3383,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4383,10 +4392,11 @@
       }
     },
     "@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
-      "dev": true
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "requires": {}
     },
     "@eslint/object-schema": {
       "version": "3.0.5",
@@ -6203,9 +6213,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
-    "@eslint/js": "^9.39.5",
+    "@eslint/js": "^10.0.1",
     "@mercuriusjs/federation": "^5.1.1",
     "@mercuriusjs/gateway": "^5.2.0",
     "dedent": "^1.0.2",
@@ -30,7 +30,7 @@
     "husky": "^9.0.11",
     "lint-staged": "^17.1.0",
     "mercurius": "^16.10.0",
-    "prettier": "^3.0.1"
+    "prettier": "^3.9.6"
   },
   "lint-staged": {
     "*.{js,jsx}": "eslint --cache --fix"


### PR DESCRIPTION
Consolidates the open Dependabot PRs listed below into a single reviewable change.
`package-lock.json` was regenerated from the updated manifest (re-derived, not merged)
so the dependency graph stays coherent.

## Included updates (npm_and_yarn)

| Package | From | To | Bump | Supersedes | Status |
|---------|------|----|------|------------|--------|
| `@eslint/js` | 9.39.5 | 10.0.1 | major | #562 | ✅ pass |
| `prettier` | 3.6.2 | 3.9.6 | minor | #552 | ✅ pass |

## Verification

- install (`npm ci`, lock resolves): ✅
- tests (`npm test`): ✅ 34 passed, 0 failed
- lint (`npm run lint`): ✅

## Follow-on fixes included

Both bumps needed a small mechanical fix to keep lint green. These are the only
source changes in this PR:

- `lib/validators.js` — `@eslint/js` 10 enables the `preserve-caught-error` rule in
  its recommended config. Attached the caught error as `cause` on the rethrown
  `Error` instead of discarding it.
- `lib/options.js` — reformatted by `prettier` 3.9.6 (collapsed a wrapped
  conditional). Applied via `eslint --fix`; no behaviour change.

Lint on `master` is clean, so both findings were introduced by these bumps rather
than pre-existing.

No bump had to be split into a follow-up PR — everything verified green together.
